### PR TITLE
Avoid braced expression in let-else

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -338,7 +338,7 @@ fn events<'a>(
         let receiver = guard.receiver.as_mut().unwrap();
 
         loop {
-            let Some(msg) = select! {
+            let Some(msg) = (select! {
                 msg = receiver.recv() => msg,
                 () = &mut end => {
                     yield make_event!(Message::Error {
@@ -346,7 +346,7 @@ fn events<'a>(
                     });
                     break
                 },
-            } else { break; };
+            }) else { break; };
 
             yield make_event!(msg.clone());
 

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -271,7 +271,7 @@ fn events<'a>(
         let guard = ConnectionGuard { lobbys: &state.lobbys, lobby, id };
 
         loop {
-            let Some(msg) = select! {
+            let Some(msg) = (select! {
                 msg = receiver.recv() => msg,
                 () = &mut end => {
                     yield make_event!(Message::Error {
@@ -279,7 +279,7 @@ fn events<'a>(
                     });
                     return;
                 },
-            } else { break; };
+            }) else { break; };
             if matches!(msg, Message::SelfLeave) {
                 break;
             }


### PR DESCRIPTION
Rust upstream tweaked the parsing on let-else slightly, to fix a syntax issue
that unintentionally slipped through. let-else wasn't intended to accept
braced blocks right before the `else`.

Add parentheses around the expression.

---

You may encounter this with the next Rust version, so sending a PR to help out. :)
